### PR TITLE
🐛 Fixes metadata title formatting issue

### DIFF
--- a/apps/clients/solo/app/layout.tsx
+++ b/apps/clients/solo/app/layout.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata() {
   };
 
   return {
-    title: `${config.title}${process.env.NODE_ENV=='development' ? " - DEV" : null}`,
+    title: `${config.title}${process.env.NODE_ENV=='development' ? " - DEV" : ""}`,
     icons: {
       icon: config.favicon,
     },

--- a/apps/clients/solo/app/page.tsx
+++ b/apps/clients/solo/app/page.tsx
@@ -97,7 +97,7 @@ export default async function IndexPage() {
           
             {/* <pre className='w-full'>{JSON.stringify(org_details,null,2)}</pre> */}
             {/* <strong>headers</strong>: {domain}/{orgSlug}/{theme} */}
-                <div className=''>
+                <div className='hidden'>
                   {domain}/{orgSlug}/{theme} - VERCEL_ENV:{process.env.VERCEL_ENV}  VERCEL:{process.env.VERCEL} NODE_ENV:{process.env.NODE_ENV}
 
                 </div>


### PR DESCRIPTION
Corrects the logic for displaying the app title in development mode by replacing `null` with an empty string for cleaner output.

Changes the visibility of environment information by hiding the div element that displays relevant URLs and environment variables, reducing clutter in the UI.
