### PR TITLE
✨ Add JSON schema for Solo Edge configuration

### DIFF
--- a/packages/utils/src/types/solo-edge-config.schema.json
+++ b/packages/utils/src/types/solo-edge-config.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Solo Edge Config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["solo"],
+  "properties": {
+    "solo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["domains", "themes", "redirects", "accountUrls"],
+      "properties": {
+        "domains": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "additionalProperties": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "themes": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "additionalProperties": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            }
+          }
+        },
+        "redirects": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^/"
+          }
+        },
+        "accountUrls": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^acct_[A-Za-z0-9]+$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This addition defines a JSON schema for Solo Edge configuration, detailing required properties and validation rules. The schema enhances configurability and lays the groundwork for dynamic edge configuration management.
