### PR TITLE
🐛 Fix calculation of platform charge in Stripe checkout session

### DIFF
--- a/apps/clients/solo/app/api/stripe/checkout_session/route.ts
+++ b/apps/clients/solo/app/api/stripe/checkout_session/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
     const isAndreas = accountId == 'acct_1RnpiyD1ZofqWwLa' ? true : false
     // console.log("IsAndreas", isAndreas, accountId)
     // console.log("Received data:", { couponCode, accountId, lineItems, cartValue });
-    const platformCharge = isAndreas || !cartValue ? 0 : Math.round((cartValue * 0.01) + 10 );
+    const platformCharge = isAndreas || !cartValue ? 0 : Math.round((cartValue * 0.015) + 15 );
 
     if(priceId) {
       console.log("Creating Stripe checkout session with priceId:", priceId);


### PR DESCRIPTION
Updated the platform charge calculation to account for increased fees, changing from 1% to 1.5% of the cart value plus a flat fee of 15p.
